### PR TITLE
Value weighting in ideology matching (1/2)

### DIFF
--- a/ideologies.js
+++ b/ideologies.js
@@ -2,7 +2,12 @@ ideologies = [
     {
         "name": "Anarcho-Communism",
         "stats": {
-            "econ": 100,
+
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 50,
             "govt": 100,
             "scty": 90
@@ -11,7 +16,11 @@ ideologies = [
     {
         "name": "Libertarian Communism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 70,
             "govt": 80,
             "scty": 80
@@ -20,7 +29,11 @@ ideologies = [
     {
         "name": "Trotskyism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 100,
             "govt": 60,
             "scty": 80
@@ -29,7 +42,11 @@ ideologies = [
     {
         "name": "Marxism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 70,
             "govt": 40,
             "scty": 80
@@ -38,7 +55,11 @@ ideologies = [
     {
         "name": "De Leonism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 30,
             "govt": 30,
             "scty": 80
@@ -47,7 +68,11 @@ ideologies = [
     {
         "name": "Leninism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 40,
             "govt": 20,
             "scty": 70
@@ -56,7 +81,11 @@ ideologies = [
     {
         "name": "Stalinism/Maoism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 20,
             "govt": 0,
             "scty": 60
@@ -65,7 +94,11 @@ ideologies = [
     {
         "name": "Religious Communism",
         "stats": {
-            "econ": 100,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 100,
             "dipl": 50,
             "govt": 30,
             "scty": 30
@@ -74,7 +107,11 @@ ideologies = [
     {
         "name": "State Socialism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 30,
             "govt": 30,
             "scty": 70
@@ -83,7 +120,11 @@ ideologies = [
     {
         "name": "Theocratic Socialism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 50,
             "govt": 30,
             "scty": 20
@@ -92,7 +133,11 @@ ideologies = [
     {
         "name": "Religious Socialism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 50,
             "govt": 70,
             "scty": 20
@@ -101,7 +146,11 @@ ideologies = [
     {
         "name": "Democratic Socialism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 50,
             "govt": 50,
             "scty": 80
@@ -110,7 +159,11 @@ ideologies = [
     {
         "name": "Revolutionary Socialism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 20,
             "govt": 50,
             "scty": 70
@@ -119,7 +172,11 @@ ideologies = [
     {
         "name": "Libertarian Socialism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 80,
             "govt": 80,
             "scty": 80
@@ -128,7 +185,11 @@ ideologies = [
     {
         "name": "Anarcho-Syndicalism",
         "stats": {
-            "econ": 80,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 80,
             "dipl": 50,
             "govt": 100,
             "scty": 80
@@ -137,7 +198,11 @@ ideologies = [
     {
         "name": "Left-Wing Populism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 40,
             "govt": 30,
             "scty": 70
@@ -146,7 +211,11 @@ ideologies = [
     {
         "name": "Theocratic Distributism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 40,
             "govt": 30,
             "scty": 20
@@ -155,7 +224,11 @@ ideologies = [
     {
         "name": "Distributism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 50,
             "govt": 50,
             "scty": 20
@@ -164,7 +237,11 @@ ideologies = [
     {
         "name": "Social Liberalism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 60,
             "govt": 60,
             "scty": 80
@@ -173,7 +250,11 @@ ideologies = [
     {
         "name": "Christian Democracy",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 60,
             "govt": 40,
             "scty": 30
@@ -182,7 +263,11 @@ ideologies = [
     {
         "name": "Social Democracy",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 70,
             "govt": 40,
             "scty": 80
@@ -191,7 +276,11 @@ ideologies = [
     {
         "name": "Progressivism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 80,
             "govt": 60,
             "scty": 100
@@ -200,7 +289,11 @@ ideologies = [
     {
         "name": "Anarcho-Mutualism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 50,
             "govt": 100,
             "scty": 70
@@ -209,7 +302,11 @@ ideologies = [
     {
         "name": "National Totalitarianism",
         "stats": {
-            "econ": 50,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 50,
             "dipl": 20,
             "govt": 0,
             "scty": 50
@@ -218,7 +315,11 @@ ideologies = [
     {
         "name": "Global Totalitarianism",
         "stats": {
-            "econ": 50,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 50,
             "dipl": 80,
             "govt": 0,
             "scty": 50
@@ -227,7 +328,11 @@ ideologies = [
     {
         "name": "Technocracy",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 60,
             "govt": 20,
             "scty": 70
@@ -236,7 +341,11 @@ ideologies = [
     {
         "name": "Centrist",
         "stats": {
-            "econ": 50,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 50,
             "dipl": 50,
             "govt": 50,
             "scty": 50
@@ -245,7 +354,11 @@ ideologies = [
     {
         "name": "Liberalism",
         "stats": {
-            "econ": 50,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 50,
             "dipl": 60,
             "govt": 60,
             "scty": 60
@@ -254,7 +367,11 @@ ideologies = [
     {
         "name": "Religious Anarchism",
         "stats": {
-            "econ": 50,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 50,
             "dipl": 50,
             "govt": 0,
             "scty": 20
@@ -263,7 +380,11 @@ ideologies = [
     {
         "name": "Right-Wing Populism",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 30,
             "govt": 30,
             "scty": 30
@@ -272,7 +393,11 @@ ideologies = [
     {
         "name": "Moderate Conservatism",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 40,
             "govt": 50,
             "scty": 30
@@ -281,7 +406,11 @@ ideologies = [
     {
         "name": "Reactionary",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			 "sctyWeight": 1.73856063, 
+			 "econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 40,
             "govt": 40,
             "scty": 10
@@ -290,7 +419,11 @@ ideologies = [
     {
         "name": "Social Libertarianism",
         "stats": {
-            "econ": 60,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 60,
             "dipl": 70,
             "govt": 80,
             "scty": 70
@@ -299,7 +432,11 @@ ideologies = [
     {
         "name": "Libertarianism",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 60,
             "govt": 80,
             "scty": 60
@@ -308,7 +445,11 @@ ideologies = [
     {
         "name": "Anarcho-Egoism",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 50,
             "govt": 100,
             "scty": 50
@@ -317,7 +458,11 @@ ideologies = [
     {
         "name": "Nazism",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 0,
             "govt": 0,
             "scty": 5
@@ -326,7 +471,11 @@ ideologies = [
     {
         "name": "Autocracy",
         "stats": {
-            "econ": 50,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 50,
             "dipl": 20,
             "govt": 20,
             "scty": 50
@@ -335,7 +484,11 @@ ideologies = [
     {
         "name": "Fascism",
         "stats": {
-            "econ": 40,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 40,
             "dipl": 20,
             "govt": 20,
             "scty": 20
@@ -344,7 +497,11 @@ ideologies = [
     {
         "name": "Capitalist Fascism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 20,
             "dipl": 20,
             "govt": 20,
             "scty": 20
@@ -353,7 +510,11 @@ ideologies = [
     {
         "name": "Conservatism",
         "stats": {
-            "econ": 30,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 30,
             "dipl": 40,
             "govt": 40,
             "scty": 20
@@ -362,7 +523,11 @@ ideologies = [
     {
         "name": "Neo-Liberalism",
         "stats": {
-            "econ": 30,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 30,
             "dipl": 30,
             "govt": 50,
             "scty": 60
@@ -371,7 +536,11 @@ ideologies = [
     {
         "name": "Classical Liberalism",
         "stats": {
-            "econ": 30,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 30,
             "dipl": 60,
             "govt": 60,
             "scty": 80
@@ -380,7 +549,11 @@ ideologies = [
     {
         "name": "Authoritarian Capitalism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 20,
             "dipl": 30,
             "govt": 20,
             "scty": 40
@@ -389,7 +562,11 @@ ideologies = [
     {
         "name": "State Capitalism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 20,
             "dipl": 50,
             "govt": 30,
             "scty": 50
@@ -398,7 +575,11 @@ ideologies = [
     {
         "name": "Neo-Conservatism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 20,
             "dipl": 20,
             "govt": 40,
             "scty": 20
@@ -407,7 +588,11 @@ ideologies = [
     {
         "name": "Fundamentalism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 20,
             "dipl": 30,
             "govt": 30,
             "scty": 5
@@ -416,7 +601,11 @@ ideologies = [
     {
         "name": "Libertarian Capitalism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.2, 
+			"econWeight": 2, 
+			"govtWeight": 2.1, 
+			"econ": 20,
             "dipl": 50,
             "govt": 80,
             "scty": 60
@@ -425,7 +614,11 @@ ideologies = [
     {
         "name": "Market Anarchism",
         "stats": {
-            "econ": 20,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 20,
             "dipl": 50,
             "govt": 100,
             "scty": 50
@@ -434,7 +627,11 @@ ideologies = [
     {
         "name": "Totalitarian Capitalism",
         "stats": {
-            "econ": 0,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 0,
             "dipl": 30,
             "govt": 0,
             "scty": 50
@@ -443,7 +640,11 @@ ideologies = [
     {
         "name": "Ultra-Capitalism",
         "stats": {
-            "econ": 0,
+            "diplWeight": 1.73856063, 
+			"sctyWeight": 1.73856063, 
+			"econWeight": 2, 
+			"govtWeight": 2, 
+			"econ": 0,
             "dipl": 40,
             "govt": 50,
             "scty": 50
@@ -452,7 +653,11 @@ ideologies = [
     {
         "name": "Anarcho-Capitalism",
         "stats": {
-            "econ": 0,
+            "diplWeight": 0, 
+			"sctyWeight": 0, 
+			"econWeight": 2.5, 
+			"govtWeight": 2.5, 
+			"econ": 0,
             "dipl": 50,
             "govt": 100,
             "scty": 50


### PR DESCRIPTION
Created new variables to allow each ideology to have a different weight for different values. This is done because some ideologies, like anarcho-capitalism, have little to nothing to do with society, while others, such as fascism, are very tradition-oriented.