### PR TITLE
Clean up CSS from Inkscape cruft

### DIFF
--- a/style.css
+++ b/style.css
@@ -27,7 +27,8 @@ p.value {
     text-indent: -16pt;
     margin-left: 20pt;
     font-size: 28px;
-    font-style:normal;font-variant:normal;font-weight:500;font-stretch:normal;line-height:2.11666656px;font-family:Montserrat;-inkscape-font-specification:'Montserrat Medium';text-align:center;letter-spacing:0px;text-anchor:middle;opacity:1;fill:#eeeeee;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:2.11666656;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:stroke fill markers
+    line-height: 2.11666656px;
+    font-family: 'Montserrat';
 }
 
 p.blurb-text {
@@ -38,7 +39,7 @@ p.axis_name {
     margin-top: 50px;
     color: #333333;
     font-size: 24px;
-    font-variant:normal;font-weight:normal;font-stretch:normal;line-height:100%;font-family:Montserrat;-inkscape-font-specification:Montserrat;text-align:center;letter-spacing:0px;word-spacing:0px;text-anchor:middle;fill:#222222;fill-opacity:1;stroke:none;stroke-width:0.13229167px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1
+    font-family: 'Montserrat';
 }
 p.question {
     margin: 16pt auto;


### PR DESCRIPTION
The changes in #140 brought a lot of inert/redundant CSS from Inkscape's default export.
This PR cleans them up, and fixes the formatting of the remaining rules to be consistent with the rest of the file.
These changes should produce no visible differences to the rendered page.